### PR TITLE
Chat page opts out of Turbo's snapshot cache

### DIFF
--- a/app/views/application/chat.html.erb
+++ b/app/views/application/chat.html.erb
@@ -1,3 +1,11 @@
+<%# The log is hydrated client-side from data-chat-narrative-value, which goes
+    stale as soon as an exchange streams. A Turbo snapshot would restore an
+    already-populated log and hydrate it again (doubling it) - and would hold
+    the decrypted narrative in the page cache after navigating away. %>
+<% content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <div data-controller="chat" data-chat-narrative-value="<%= @narrative.to_json %>" data-chat-universe-time-value="<%= current_resonance.universe_time %>" data-chat-saved-textarea-value="<%= h(current_resonance.textarea || "") %>" class="chat-container">
   <div id="chat-log" data-chat-target="log" class="chat-log">
     <!-- Messages will appear here -->

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -153,6 +153,15 @@ RSpec.describe ApplicationController, type: :request do
         expect(response.body).to include("https://github.com/lightward/yours/blob/main/README.md")
       end
 
+      it "opts the chat page out of Turbo's snapshot cache" do
+        # The chat log is hydrated client-side from a narrative value that goes
+        # stale as soon as an exchange streams. Restoring a snapshot would
+        # hydrate over an already-populated log (doubling it), and would keep
+        # the decrypted narrative in the page cache after navigating away.
+        get root_path
+        expect(response.body).to include('<meta name="turbo-cache-control" content="no-cache">')
+      end
+
       it "shows 'day X' format for day 2+" do
         resonance.universe_day = 5
         resonance.save!

--- a/test/controllers/sleep_controller.test.js
+++ b/test/controllers/sleep_controller.test.js
@@ -12,7 +12,9 @@ describe('SleepController', () => {
     shutdown: vi.fn()
   }
 
-  const MockLightwardAura = vi.fn(() => mockAura)
+  // A plain function, not an arrow: the controller calls `new LightwardAura(...)`,
+  // and vitest 4 constructs the implementation - arrows aren't constructible
+  const MockLightwardAura = vi.fn(function () { return mockAura })
   MockLightwardAura.defaultParams = {
     width: 800,
     height: 600


### PR DESCRIPTION
## What

Starting on /chat, navigating to settings, then navigating back (via Turbo) doubled the chat log — the narrative concat'd to itself.

## Why

The chat log ships empty and is hydrated by `chat_controller#connect()` from `data-chat-narrative-value`. Turbo Drive snapshots the page *as populated* when you navigate away, and back-navigation is a restoration visit rendered straight from that snapshot — log already full, then `connect()` hydrates the whole narrative on top of it.

## Fix

`turbo-cache-control: no-cache` on the chat page (via `content_for :head`). Back-navigation becomes a fresh request; the server renders the current narrative once.

Deliberately **not** fixed by making `connect()` idempotent-by-clearing: `narrativeValue` goes stale the moment an exchange streams (new messages live only in the DOM and on the server), so rebuilding from the attribute would silently drop the newest exchange. The server is the only honest source for this page.

Quiet bonus, aligned with the encryption posture: the decrypted narrative no longer lingers in Turbo's in-memory page cache after you've left the page.

## Spec

New request spec protects the invariant (the chat page declares no-cache) rather than the symptom. 190 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)