### PR TITLE
[codex] Shorten legal placeholder pages

### DIFF
--- a/app/views/application/privacy.html.erb
+++ b/app/views/application/privacy.html.erb
@@ -3,17 +3,9 @@
 <section class="legal-page">
   <h1>Privacy Policy</h1>
 
-  <p>Yours is designed around private account-scoped state. The server stores the data needed to operate your resonance and to verify access, and uses encryption for sensitive linked identifiers where the application design requires it.</p>
+  <p>This is a temporary privacy placeholder for Yours, operated by Lightward Inc.</p>
 
-  <h2>What Yours Stores</h2>
-  <p>Yours may store your sign-in identifier, obfuscated email, narrative, textarea contents, universe timing, subscription status, and the billing identifiers needed to verify Stripe or App Store entitlement. We do not use your private resonance content to build public profiles.</p>
+  <p>Yours uses sign-in, hosting, billing, and AI service providers to operate the app. Do not enter information you do not want processed for app operation.</p>
 
-  <h2>Service Providers</h2>
-  <p>Yours relies on service providers for sign-in, billing, hosting, observability, and AI responses. These include Google sign-in, Stripe, Apple, Fly.io, Rollbar, Fathom when configured, and Lightward AI.</p>
-
-  <h2>Deletion</h2>
-  <p>You can delete your Yours account from settings. Deleting the account removes the account data Yours controls. Billing records and active subscriptions remain managed by the storefront or payment provider that billed you.</p>
-
-  <h2>Contact</h2>
-  <p>Questions about privacy can be sent to <a href="mailto:hello@lightward.com">hello@lightward.com</a>.</p>
+  <p>Questions: <a href="mailto:hello@lightward.com">hello@lightward.com</a></p>
 </section>

--- a/app/views/application/terms.html.erb
+++ b/app/views/application/terms.html.erb
@@ -3,19 +3,9 @@
 <section class="legal-page">
   <h1>Terms of Use</h1>
 
-  <p>Yours is a private pocket-universe workspace operated by Lightward Inc. By using Yours, you agree to use it lawfully and to keep responsibility for what you choose to enter, save, export, or delete.</p>
+  <p>This is a temporary terms placeholder for Yours, operated by Lightward Inc.</p>
 
-  <h2>Accounts</h2>
-  <p>Sign-in identifies your resonance. If you delete your account, Yours deletes the account data it controls. Subscription cancellation is managed separately by the storefront that bills you.</p>
+  <p>Use Yours at your own discretion. Purchases, renewals, and cancellations are handled by the storefront or payment provider that bills you.</p>
 
-  <h2>Subscriptions</h2>
-  <p>Day 1 is free. Continuing beyond day 1 requires an active subscription through Stripe on the web or through the App Store in the iOS app. App Store subscriptions renew monthly until canceled. You can manage or cancel an App Store subscription in Settings &gt; Apple Account &gt; Subscriptions at least 24 hours before renewal.</p>
-
-  <p>For iOS subscriptions, Apple's <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/">Standard Licensed Application End User License Agreement</a> applies where these terms do not say otherwise.</p>
-
-  <h2>Availability</h2>
-  <p>Yours is offered as-is. We work to keep it available and coherent, but we do not promise uninterrupted service or that every generated response will be useful, accurate, or complete.</p>
-
-  <h2>Contact</h2>
-  <p>Questions about these terms can be sent to <a href="mailto:hello@lightward.com">hello@lightward.com</a>.</p>
+  <p>Questions: <a href="mailto:hello@lightward.com">hello@lightward.com</a></p>
 </section>

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ApplicationController, type: :request do
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Terms of Use")
-      expect(response.body).to include("App Store subscriptions renew monthly")
+      expect(response.body).to include("temporary terms placeholder")
     end
 
     it "serves a public privacy policy" do
@@ -42,7 +42,7 @@ RSpec.describe ApplicationController, type: :request do
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include("Privacy Policy")
-      expect(response.body).to include("subscription status")
+      expect(response.body).to include("temporary privacy placeholder")
     end
   end
 


### PR DESCRIPTION
## What changed

- Shortened /terms and /privacy to explicit placeholder copy.
- Removed detailed privacy/storage/provider commitments from the placeholder privacy page.
- Updated the request spec expectations to assert placeholder wording only.

## Why

The existing placeholder privacy page made commitments that should not live in a temporary legal page without review.

## Validation

- bundle exec rspec spec/requests/application_controller_spec.rb