### PR TITLE
Polish native iOS app flows

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -118,6 +118,17 @@ Cancellation has no native path: the OS owns subscription management
 and describe where to manage it, the same way the web app owns Stripe's
 cancel flow.
 
+Native settings must expose Terms of Use and Privacy Policy links for signed-in
+users, even when they are not looking at the purchase wall. The purchase wall
+also keeps those links adjacent to the StoreKit / Play Billing controls.
+
+Restore purchase is an entitlement re-sync, not a new checkout: ask the
+storefront to refresh receipts, walk current entitlements, and POST any
+matching transaction back through `POST /native/subscription`. If a matching
+entitlement exists but the server cannot verify it, show that verification
+failure. Only show "no active subscription found" when no matching current
+entitlement is present.
+
 ## Continuity (cross-device safety)
 
 Send `Assert-Yours-Universe-Time: <day>:<message count>` with `POST /stream`
@@ -149,9 +160,22 @@ as `event: <name>\ndata: <json>\n\n`:
 - `message_stop` — message complete; apply full markdown treatment
 - `universe_time` — `{ universe_time }`: the server saved the narrative;
   adopt this value
-- `error` — `{ error: { message } }`: display it
+- `error` — `{ error: { message } }`: terminal for that exchange. Stop
+  applying subsequent stream events, remove the assistant placeholder, keep
+  the failed user bubble marked, restore the text to the composer, and offer
+  retry. If the message says the space moved forward elsewhere, offer refresh
+  instead.
 - `end` — always last; **arrives with no data line and no trailing blank
   line**, so flush your parser at EOF
+
+## Sleep integration
+
+`POST /sleep` returns `starting_universe_time`; native clients poll
+`/native/state` once per second until the returned `universe_time` differs.
+Match the web's minimum five-second display before showing Continue. Timeout
+after 300 seconds, with an affordance to check again. Do not reopen chat from
+the pre-sleep local state; only `GET /native/state` can move the app out of
+the sleep phase after integration begins.
 
 ## Rendering rules shared by all clients
 
@@ -174,3 +198,7 @@ The composer draft saves locally on every keystroke (web: localStorage;
 iOS: UserDefaults, key `yours-input-<universe_time>`) and to the server
 (`PUT /textarea`) after 1.5s of stillness. On load, prefer whichever of
 server/local is longer. Clear both when a message sends.
+
+If a send fails before settlement, restore the attempted text into the
+composer and persist it under the current draft key. Keep the failed user
+message visible as a warning marker until the person refreshes or retries.

--- a/ios/Yours/AppModel.swift
+++ b/ios/Yours/AppModel.swift
@@ -272,7 +272,7 @@ final class AppModel: ObservableObject {
                 for try await event in events {
                     if event.name == "error" {
                         streamErrorMessage = event.errorMessage ?? "An error occurred"
-                        continue
+                        break
                     }
                     handle(event, id: streamingID)
                 }
@@ -344,6 +344,8 @@ final class AppModel: ObservableObject {
     }
 
     private func restoreFailedSend(_ text: String, userMessageID: UUID) {
+        // Keep the failed user bubble visible and warning-colored while the
+        // editable draft is restored below.
         updateStreaming(userMessageID) {
             $0.isComplete = true
             $0.isError = true
@@ -371,13 +373,6 @@ final class AppModel: ObservableObject {
             if let time = event.universeTime {
                 state?.universeTime = time
             }
-        case "error":
-            updateStreaming(id) {
-                $0.isPulsing = false
-                $0.isComplete = true
-                $0.isError = true
-                $0.text = "⚠️ \(event.errorMessage ?? "An error occurred")"
-            }
         case "end":
             updateStreaming(id) { $0.isPulsing = false }
         default:
@@ -395,6 +390,7 @@ final class AppModel: ObservableObject {
         case .retrySend(let text, let failedMessageID):
             self.notice = nil
             removeMessage(failedMessageID)
+            isWaiting = false
             composerText = text
             send()
         }

--- a/ios/Yours/AppModel.swift
+++ b/ios/Yours/AppModel.swift
@@ -33,6 +33,7 @@ final class AppModel: ObservableObject {
     enum NoticeAction: Equatable {
         case refresh
         case signIn
+        case retrySend(text: String, failedMessageID: UUID)
     }
 
     @Published var phase: Phase = .loading
@@ -40,6 +41,7 @@ final class AppModel: ObservableObject {
     @Published var messages: [DisplayMessage] = []
     @Published var composerText = ""
     @Published var isWaiting = false
+    @Published var isSigningIn = false
     @Published var notice: Notice?
     @Published var landingError: String?
     @Published var sleepStartingTime: String?
@@ -98,15 +100,20 @@ final class AppModel: ObservableObject {
 
     // Permanent account deletion (App Store 5.1.1v). Destroys the resonance
     // server-side, then returns to the landing screen.
-    func deleteAccount() async {
+    func deleteAccount() async -> Bool {
         #if DEBUG
-        if mock != nil { signOut(); return }
+        if mock != nil {
+            signOut()
+            return true
+        }
         #endif
         do {
             try await api.deleteAccount()
             signOut()
+            return true
         } catch {
             notice = Notice(message: "Couldn't delete the account just now.", actionLabel: "Try again", action: .refresh)
+            return false
         }
     }
 
@@ -193,6 +200,11 @@ final class AppModel: ObservableObject {
     // MARK: - Auth
 
     func signIn() async {
+        guard !isSigningIn else { return }
+        isSigningIn = true
+        landingError = nil
+        defer { isSigningIn = false }
+
         do {
             let result = try await authFlow.signIn(api: api)
             Keychain.token = result.token
@@ -228,7 +240,9 @@ final class AppModel: ObservableObject {
         guard !text.isEmpty, !isWaiting, let universeTime = state?.universeTime else { return }
 
         notice = nil
-        messages.append(DisplayMessage(role: "user", text: text))
+        let userMessage = DisplayMessage(role: "user", text: text, isComplete: false)
+        let userMessageID = userMessage.id
+        messages.append(userMessage)
         composerText = ""
         isWaiting = true
         clearDraft()
@@ -247,18 +261,44 @@ final class AppModel: ObservableObject {
             #if DEBUG
             if mock != nil {
                 await MockData.streamResponse(into: self, id: streamingID)
+                updateStreaming(userMessageID) { $0.isComplete = true }
                 isWaiting = false
                 return
             }
             #endif
             do {
                 let events = try await api.stream(message: .user(text), universeTime: universeTime)
+                var streamErrorMessage: String?
                 for try await event in events {
+                    if event.name == "error" {
+                        streamErrorMessage = event.errorMessage ?? "An error occurred"
+                        continue
+                    }
                     handle(event, id: streamingID)
                 }
-                updateStreaming(streamingID) { $0.isPulsing = false; $0.isComplete = true }
+                if let streamErrorMessage {
+                    removeMessage(streamingID)
+                    restoreFailedSend(text, userMessageID: userMessageID)
+                    if streamErrorMessage.localizedCaseInsensitiveContains("moved forward") {
+                        notice = Notice(
+                            message: streamErrorMessage,
+                            actionLabel: "Refresh to continue",
+                            action: .refresh
+                        )
+                    } else {
+                        notice = Notice(
+                            message: "Message didn't send. I put it back in the composer.",
+                            actionLabel: "Send again",
+                            action: .retrySend(text: text, failedMessageID: userMessageID)
+                        )
+                    }
+                } else {
+                    updateStreaming(userMessageID) { $0.isComplete = true }
+                    updateStreaming(streamingID) { $0.isPulsing = false; $0.isComplete = true }
+                }
             } catch APIError.divergence(let message) {
                 removeMessage(streamingID)
+                restoreFailedSend(text, userMessageID: userMessageID)
                 notice = Notice(
                     message: message.isEmpty
                         ? "This space moved forward elsewhere. Refresh to join where it is now."
@@ -268,6 +308,7 @@ final class AppModel: ObservableObject {
                 )
             } catch APIError.unauthenticated {
                 removeMessage(streamingID)
+                restoreFailedSend(text, userMessageID: userMessageID)
                 notice = Notice(
                     message: "Your session has expired. Sign in to continue.",
                     actionLabel: "Sign in",
@@ -275,14 +316,16 @@ final class AppModel: ObservableObject {
                 )
             } catch APIError.subscriptionRequired {
                 removeMessage(streamingID)
+                restoreFailedSend(text, userMessageID: userMessageID)
                 await refreshState()
             } catch {
-                updateStreaming(streamingID) {
-                    $0.isPulsing = false
-                    $0.isComplete = true
-                    $0.isError = true
-                    $0.text = "⚠️ Error: the stream broke. Your message wasn't lost on the web side — refresh to see where things stand."
-                }
+                removeMessage(streamingID)
+                restoreFailedSend(text, userMessageID: userMessageID)
+                notice = Notice(
+                    message: "Message didn't send. I put it back in the composer.",
+                    actionLabel: "Send again",
+                    action: .retrySend(text: text, failedMessageID: userMessageID)
+                )
             }
             isWaiting = false
         }
@@ -298,6 +341,17 @@ final class AppModel: ObservableObject {
 
     private func removeMessage(_ id: UUID) {
         messages.removeAll { $0.id == id }
+    }
+
+    private func restoreFailedSend(_ text: String, userMessageID: UUID) {
+        updateStreaming(userMessageID) {
+            $0.isComplete = true
+            $0.isError = true
+        }
+        if composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            composerText = text
+            UserDefaults.standard.set(text, forKey: draftKey)
+        }
     }
 
     private func handle(_ event: SSEEvent, id: UUID) {
@@ -338,6 +392,11 @@ final class AppModel: ObservableObject {
             Task { await refreshState() }
         case .signIn:
             signOut()
+        case .retrySend(let text, let failedMessageID):
+            self.notice = nil
+            removeMessage(failedMessageID)
+            composerText = text
+            send()
         }
     }
 
@@ -440,15 +499,17 @@ final class AppModel: ObservableObject {
         settingsSubscription = try? await api.state(includeSubscription: true).subscription
     }
 
-    func startOver() async {
+    func startOver() async -> Bool {
         #if DEBUG
-        if mock != nil { return }
+        if mock != nil { return true }
         #endif
         do {
             try await api.reset()
             await refreshState()
+            return true
         } catch {
             notice = Notice(message: "Couldn't start over just now.", actionLabel: "Try again", action: .refresh)
+            return false
         }
     }
 

--- a/ios/Yours/Networking/AuthFlow.swift
+++ b/ios/Yours/Networking/AuthFlow.swift
@@ -12,8 +12,11 @@ final class AuthFlow: NSObject, ASWebAuthenticationPresentationContextProviding 
     private var callbackContinuation: CheckedContinuation<URL, Error>?
 
     struct Cancelled: Error {}
+    struct AlreadyActive: Error {}
 
     func signIn(api: YoursAPI) async throws -> (token: String, obfuscatedEmail: String?) {
+        guard activeSession == nil else { throw AlreadyActive() }
+
         let verifier = Self.randomVerifier()
         let challenge = Self.challenge(for: verifier)
 
@@ -49,7 +52,11 @@ final class AuthFlow: NSObject, ASWebAuthenticationPresentationContextProviding 
             // behind an explicit confirmation tap; this is the matching half.)
             session.prefersEphemeralWebBrowserSession = true
             activeSession = session
-            session.start()
+            if !session.start() {
+                activeSession = nil
+                callbackContinuation = nil
+                continuation.resume(throwing: Cancelled())
+            }
         }
 
         guard let code = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)?

--- a/ios/Yours/Store.swift
+++ b/ios/Yours/Store.swift
@@ -81,6 +81,11 @@ final class Store: ObservableObject {
         } catch APIError.unauthenticated {
             purchaseError = "Sign in again before purchasing."
             return nil
+        } catch APIError.subscriptionRequired(let message) {
+            purchaseError = message.isEmpty
+                ? "That App Store purchase belongs to a different Yours account."
+                : message
+            return nil
         } catch APIError.divergence {
             purchaseError = "That App Store subscription is already linked to another Yours account."
             return nil
@@ -131,6 +136,13 @@ final class Store: ObservableObject {
                     purchaseError = "That App Store subscription is already linked to another Yours account."
                 }
                 return nil
+            } catch APIError.subscriptionRequired(let message) {
+                if reportErrors {
+                    purchaseError = message.isEmpty
+                        ? "That App Store purchase belongs to a different Yours account."
+                        : message
+                    return nil
+                }
             } catch APIError.unauthenticated {
                 if reportErrors {
                     purchaseError = "Sign in again before restoring purchases."
@@ -150,7 +162,7 @@ final class Store: ObservableObject {
 
     // Hand the JWS representation to the server, which is the authority on
     // whether it's genuine. We finish the transaction once the server has it.
-    private func submit(_ verification: VerificationResult<Transaction>, api: YoursAPI) async throws -> UniverseState? {
+    private func submit(_ verification: VerificationResult<Transaction>, api: YoursAPI) async throws -> UniverseState {
         let signed = verification.jwsRepresentation
         let state = try await api.verifySubscription(platform: "apple", signedTransaction: signed)
         if case .verified(let transaction) = verification {
@@ -169,9 +181,8 @@ final class Store: ObservableObject {
         else { return }
 
         do {
-            if let state = try await submit(verification, api: api) {
-                onSyncedState(state)
-            }
+            let state = try await submit(verification, api: api)
+            onSyncedState(state)
             purchaseError = nil
         } catch APIError.http(422) {
             // StoreKit verified the transaction, but the server found no

--- a/ios/Yours/Store.swift
+++ b/ios/Yours/Store.swift
@@ -78,6 +78,15 @@ final class Store: ObservableObject {
             @unknown default:
                 return nil
             }
+        } catch APIError.unauthenticated {
+            purchaseError = "Sign in again before purchasing."
+            return nil
+        } catch APIError.divergence {
+            purchaseError = "That App Store subscription is already linked to another Yours account."
+            return nil
+        } catch APIError.http(502) {
+            purchaseError = "The App Store purchase couldn't be verified just now. Tap Restore purchase to retry."
+            return nil
         } catch {
             purchaseError = "Purchase didn't complete. Try again?"
             return nil
@@ -90,8 +99,14 @@ final class Store: ObservableObject {
         purchaseError = nil
         defer { purchasing = false }
 
-        if let state = await syncExistingEntitlement(api: api) {
+        try? await AppStore.sync()
+
+        if let state = await syncExistingEntitlement(api: api, reportErrors: true) {
             return state
+        }
+
+        if purchaseError != nil {
+            return nil
         }
 
         purchaseError = "No active subscription found to restore."
@@ -102,14 +117,31 @@ final class Store: ObservableObject {
     // purchase prompt. Unlike the explicit restore button, this does not set
     // loading/error UI: if nothing verifies, the normal subscription choices
     // are shown.
-    func syncExistingEntitlement(api: YoursAPI) async -> UniverseState? {
+    func syncExistingEntitlement(api: YoursAPI, reportErrors: Bool = false) async -> UniverseState? {
         for await result in Transaction.currentEntitlements {
             guard case .verified(let transaction) = result,
                   Self.productIDs.contains(transaction.productID)
             else { continue }
 
-            if let state = try? await submit(result, api: api) {
+            do {
+                let state = try await submit(result, api: api)
                 return state
+            } catch APIError.divergence {
+                if reportErrors {
+                    purchaseError = "That App Store subscription is already linked to another Yours account."
+                }
+                return nil
+            } catch APIError.unauthenticated {
+                if reportErrors {
+                    purchaseError = "Sign in again before restoring purchases."
+                    return nil
+                }
+            } catch {
+                if reportErrors {
+                    purchaseError = "Couldn't verify the App Store purchase just now. Try Restore purchase again in a minute."
+                    return nil
+                }
+                continue
             }
         }
 

--- a/ios/Yours/Views/ChatScreen.swift
+++ b/ios/Yours/Views/ChatScreen.swift
@@ -70,27 +70,32 @@ struct ChatScreen: View {
     }
 
     private var header: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 12) {
             Text("Yours: \(model.state?.dayWithUnits ?? "")")
                 .font(.yoursMono(14))
                 .foregroundStyle(Theme.accent)
+                .lineLimit(1)
+                .layoutPriority(1)
 
-            Spacer()
+            Spacer(minLength: 8)
 
-            if let email = model.state?.obfuscatedEmail {
-                Button(email) { showSettings = true }
-                    .font(.yoursMono(14))
-                    .foregroundStyle(Theme.accent)
-                    .accessibilityIdentifier("settings-button")
+            Button {
+                showSettings = true
+            } label: {
+                Text(model.state?.obfuscatedEmail ?? "Settings")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
+            .buttonStyle(TextActionButtonStyle(color: Theme.accent))
+            .frame(maxWidth: 150, alignment: .trailing)
+            .accessibilityIdentifier("settings-button")
 
             Button("Exit") { showExitConfirm = true }
-                .font(.yoursMono(14))
-                .foregroundStyle(Theme.accentActive)
+                .buttonStyle(TextActionButtonStyle(color: Theme.accentActive))
                 .accessibilityIdentifier("exit-button")
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 12)
+        .padding(.vertical, 6)
         .background(Theme.background)
         .overlay(alignment: .bottom) {
             Rectangle()
@@ -164,8 +169,7 @@ struct ChatScreen: View {
             Button("Move to \(UniverseState.dayWithUnits(nextDay))") {
                 showSleepConfirm = true
             }
-            .font(.yoursMono(13))
-            .foregroundStyle(Theme.accentActive)
+            .buttonStyle(TextActionButtonStyle(color: Theme.accentActive))
             .accessibilityIdentifier("next-day-button")
         } else {
             // Day 1 visitor — same words as the web; the path runs
@@ -173,16 +177,14 @@ struct ChatScreen: View {
             Button("Subscribe for \(UniverseState.dayWithUnits(nextDay))") {
                 showSettings = true
             }
-            .font(.yoursMono(13))
-            .foregroundStyle(Theme.accent)
+            .buttonStyle(TextActionButtonStyle(color: Theme.accent))
             .accessibilityIdentifier("next-day-button")
         }
     }
 
     private var saveButton: some View {
         Button("Save") { exportNarrative() }
-            .font(.yoursMono(13))
-            .foregroundStyle(Theme.foreground.opacity(0.6))
+            .buttonStyle(TextActionButtonStyle(color: Theme.foreground.opacity(0.65)))
             .accessibilityIdentifier("save-button")
     }
 
@@ -231,7 +233,7 @@ struct MessageView: View {
                 Text(message.isComplete ? MarkdownLite.rendered(message.text) : MarkdownLite.streaming(message.text))
                     .font(.yoursMono(15))
                     .lineSpacing(3)
-                    .foregroundStyle(Theme.foreground)
+                    .foregroundStyle(message.isError ? Theme.warning : Theme.foreground)
                     .textSelection(.enabled)
             }
         }

--- a/ios/Yours/Views/LandingView.swift
+++ b/ios/Yours/Views/LandingView.swift
@@ -80,7 +80,7 @@ struct TextActionButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.yoursMono(14))
-            .foregroundStyle(configuration.isPressed ? Theme.accentActive : color)
+            .foregroundStyle(color)
             .padding(.horizontal, 4)
             .frame(minWidth: 44, minHeight: 44)
             .contentShape(Rectangle())

--- a/ios/Yours/Views/LandingView.swift
+++ b/ios/Yours/Views/LandingView.swift
@@ -28,11 +28,12 @@ struct LandingView: View {
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 48)
 
-            Button("Enter via Google") {
+            Button(model.isSigningIn ? "Opening Google..." : "Enter via Google") {
                 Task { await model.signIn() }
             }
             .buttonStyle(WebButtonStyle())
             .accessibilityIdentifier("landing-google-button")
+            .disabled(model.isSigningIn)
 
             if let error = model.landingError {
                 Text(error)
@@ -61,6 +62,7 @@ struct WebButtonStyle: ButtonStyle {
             .foregroundStyle(configuration.isPressed ? Theme.background : color)
             .padding(.vertical, 8)
             .padding(.horizontal, 16)
+            .frame(minHeight: 44)
             .background(configuration.isPressed ? color : Theme.borderLight)
             .overlay(alignment: .leading) {
                 Rectangle()
@@ -69,5 +71,20 @@ struct WebButtonStyle: ButtonStyle {
             }
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
+    }
+}
+
+struct TextActionButtonStyle: ButtonStyle {
+    var color: Color = Theme.accent
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.yoursMono(14))
+            .foregroundStyle(configuration.isPressed ? Theme.accentActive : color)
+            .padding(.horizontal, 4)
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+            .opacity(configuration.isPressed ? 0.7 : 1)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
     }
 }

--- a/ios/Yours/Views/LockedView.swift
+++ b/ios/Yours/Views/LockedView.swift
@@ -8,32 +8,31 @@ struct LockedView: View {
     @State private var showExitConfirm = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
+        ScrollView {
+            VStack(spacing: 0) {
+                Text("Yours: \(model.state.map(\.dayWithUnits) ?? "")")
+                    .textCase(.uppercase)
+                    .font(.yoursHeading(24))
+                    .foregroundStyle(Theme.foregroundHeading)
+                    .padding(.bottom, 20)
 
-            Text("Yours: \(model.state.map(\.dayWithUnits) ?? "")")
-                .textCase(.uppercase)
-                .font(.yoursHeading(24))
-                .foregroundStyle(Theme.foregroundHeading)
-                .padding(.bottom, 20)
+                Text("Subscribe to continue with \(model.state.map(\.dayWithUnits) ?? "this day").")
+                    .font(.yoursMono(15))
+                    .foregroundStyle(Theme.foreground)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, 28)
 
-            Text("Subscribe to continue with \(model.state.map(\.dayWithUnits) ?? "this day").")
-                .font(.yoursMono(15))
-                .foregroundStyle(Theme.foreground)
-                .multilineTextAlignment(.center)
-                .padding(.bottom, 28)
+                SubscribeOptions()
+                    .padding(.bottom, 20)
 
-            SubscribeOptions()
-                .padding(.bottom, 24)
-
-            Spacer()
-
-            Button("Exit") { showExitConfirm = true }
-                .font(.yoursMono(14))
-                .foregroundStyle(Theme.accentActive)
-                .padding(.bottom, 24)
+                Button("Exit") { showExitConfirm = true }
+                    .buttonStyle(TextActionButtonStyle(color: Theme.accentActive))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 48)
         }
-        .padding(.horizontal, 32)
+        .background(Theme.background)
         .confirmationDialog("Exit?", isPresented: $showExitConfirm, titleVisibility: .visible) {
             Button("Exit", role: .destructive) { model.signOut() }
         }

--- a/ios/Yours/Views/SettingsView.swift
+++ b/ios/Yours/Views/SettingsView.swift
@@ -114,7 +114,7 @@ struct SettingsView: View {
                     .font(.yoursBody(15))
                     .foregroundStyle(Theme.foreground.opacity(0.6))
                     .padding(.top, 6)
-                Button("Manage Stripe on web") {
+                Button("Manage subscription on web") {
                     if let url = URL(string: "https://yours.fyi/settings") {
                         openURL(url)
                     }
@@ -145,9 +145,9 @@ struct SettingsView: View {
     private var legalBody: some View {
         VStack(alignment: .leading, spacing: 8) {
             Link("Terms of Use", destination: URL(string: "https://yours.fyi/terms")!)
-                .frame(minHeight: 44, alignment: .leading)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
             Link("Privacy Policy", destination: URL(string: "https://yours.fyi/privacy")!)
-                .frame(minHeight: 44, alignment: .leading)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
         }
         .font(.yoursMono(14))
         .foregroundStyle(Theme.accent)

--- a/ios/Yours/Views/SettingsView.swift
+++ b/ios/Yours/Views/SettingsView.swift
@@ -21,8 +21,7 @@ struct SettingsView: View {
                             .accessibilityIdentifier("settings-title")
                         Spacer()
                         Button("Done") { dismiss() }
-                            .font(.yoursMono(14))
-                            .foregroundStyle(Theme.accent)
+                            .buttonStyle(TextActionButtonStyle(color: Theme.accent))
                             .accessibilityIdentifier("settings-done-button")
                     }
 
@@ -35,12 +34,17 @@ struct SettingsView: View {
                                 .buttonStyle(WebButtonStyle(
                                     color: model.themePreference == preference ? Theme.accentActive : Theme.accent
                                 ))
+                                .accessibilityValue(model.themePreference == preference ? "Selected" : "")
                             }
                         }
                     }
 
                     section("Subscription") {
                         subscriptionBody
+                    }
+
+                    section("Legal") {
+                        legalBody
                     }
 
                     section("Start over") {
@@ -58,8 +62,9 @@ struct SettingsView: View {
         .confirmationDialog("Start over?", isPresented: $showStartOverConfirm, titleVisibility: .visible) {
             Button("Start over", role: .destructive) {
                 Task {
-                    await model.startOver()
-                    dismiss()
+                    if await model.startOver() {
+                        dismiss()
+                    }
                 }
             }
         } message: {
@@ -68,8 +73,9 @@ struct SettingsView: View {
         .confirmationDialog("Delete your account?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
             Button("Delete everything", role: .destructive) {
                 Task {
-                    await model.deleteAccount()
-                    dismiss()
+                    if await model.deleteAccount() {
+                        dismiss()
+                    }
                 }
             }
         } message: {
@@ -84,8 +90,7 @@ struct SettingsView: View {
                 .font(.yoursBody(16))
                 .foregroundStyle(Theme.foreground)
             Button("Delete account") { showDeleteConfirm = true }
-                .font(.yoursMono(14))
-                .foregroundStyle(Theme.error)
+                .buttonStyle(TextActionButtonStyle(color: Theme.error))
             Text("There is no undo.")
                 .font(.yoursBody(14))
                 .foregroundStyle(Theme.warning)
@@ -109,7 +114,7 @@ struct SettingsView: View {
                     .font(.yoursBody(15))
                     .foregroundStyle(Theme.foreground.opacity(0.6))
                     .padding(.top, 6)
-                Button("Manage on web") {
+                Button("Manage Stripe on web") {
                     if let url = URL(string: "https://yours.fyi/settings") {
                         openURL(url)
                     }
@@ -137,6 +142,18 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private var legalBody: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Link("Terms of Use", destination: URL(string: "https://yours.fyi/terms")!)
+                .frame(minHeight: 44, alignment: .leading)
+            Link("Privacy Policy", destination: URL(string: "https://yours.fyi/privacy")!)
+                .frame(minHeight: 44, alignment: .leading)
+        }
+        .font(.yoursMono(14))
+        .foregroundStyle(Theme.accent)
+    }
+
+    @ViewBuilder
     private var startOverBody: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Begin at the beginning, at the dawn of \(UniverseState.dayWithUnits(1)), with no trace of what was.")
@@ -145,8 +162,7 @@ struct SettingsView: View {
 
             if model.state?.subscriptionActive == true {
                 Button("Start over") { showStartOverConfirm = true }
-                    .font(.yoursMono(14))
-                    .foregroundStyle(Theme.accentActive)
+                    .buttonStyle(TextActionButtonStyle(color: Theme.accentActive))
                 Text("There is no undo.")
                     .font(.yoursBody(14))
                     .foregroundStyle(Theme.warning)

--- a/ios/Yours/Views/SleepView.swift
+++ b/ios/Yours/Views/SleepView.swift
@@ -8,7 +8,9 @@ struct SleepView: View {
     @EnvironmentObject private var model: AppModel
     @State private var dots = ""
     @State private var finished = false
+    @State private var timedOut = false
     @State private var auraVisible = true
+    @State private var integrationTaskID = UUID()
 
     var body: some View {
         ZStack {
@@ -21,11 +23,32 @@ struct SleepView: View {
 
             if finished {
                 Button("Continue") {
-                    Task { await model.refreshState() }
+                    Task {
+                        await model.refreshState()
+                    }
                 }
-                .font(.yoursMono(14))
-                .foregroundStyle(Theme.accent)
+                .buttonStyle(WebButtonStyle())
                 .accessibilityIdentifier("sleep-continue-button")
+            } else if timedOut {
+                VStack(spacing: 16) {
+                    Text("Still integrating \(model.state.map(\.dayWithUnits) ?? "the day").")
+                        .font(.yoursMono(14))
+                        .foregroundStyle(Theme.accentActive)
+                        .multilineTextAlignment(.center)
+
+                    Button("Check again") {
+                        timedOut = false
+                        auraVisible = true
+                        integrationTaskID = UUID()
+                    }
+                    .buttonStyle(WebButtonStyle())
+
+                    Button("Exit") {
+                        model.signOut()
+                    }
+                    .buttonStyle(TextActionButtonStyle(color: Theme.accent))
+                }
+                .padding(24)
             } else {
                 Text("Integrating \(model.state.map(\.dayWithUnits) ?? "the day")\(dots)")
                     .font(.yoursMono(14))
@@ -33,14 +56,14 @@ struct SleepView: View {
                     .accessibilityIdentifier("sleep-integrating-label")
             }
         }
-        .task { await animateEllipsis() }
-        .task { await awaitIntegration() }
+        .task(id: integrationTaskID) { await animateEllipsis() }
+        .task(id: integrationTaskID) { await awaitIntegration() }
     }
 
     private func animateEllipsis() async {
         let states = ["", ".", "..", "..."]
         var index = 0
-        while !Task.isCancelled && !finished {
+        while !Task.isCancelled && !finished && !timedOut {
             dots = states[index]
             index = (index + 1) % states.count
             try? await Task.sleep(for: .milliseconds(500))
@@ -49,11 +72,22 @@ struct SleepView: View {
 
     private func awaitIntegration() async {
         let start = Date()
+        let timeout: TimeInterval = 300
         while !Task.isCancelled {
-            if await model.sleepIntegrationFinished() { break }
+            if await model.sleepIntegrationFinished() {
+                await finishIntegration(startedAt: start)
+                return
+            }
+            if Date().timeIntervalSince(start) >= timeout {
+                auraVisible = false
+                timedOut = true
+                return
+            }
             try? await Task.sleep(for: .seconds(1))
         }
+    }
 
+    private func finishIntegration(startedAt start: Date) async {
         // Match the web's minimum display: the night deserves its moment
         let minimum: TimeInterval = 5
         let elapsed = Date().timeIntervalSince(start)

--- a/ios/Yours/Views/SubscribeOptions.swift
+++ b/ios/Yours/Views/SubscribeOptions.swift
@@ -15,6 +15,10 @@ struct SubscribeOptions: View {
                 .font(.yoursBody(16))
                 .foregroundStyle(Theme.foreground)
 
+            Text("Each monthly tier unlocks the same ongoing access. Choose what fits.")
+                .font(.yoursBody(14))
+                .foregroundStyle(Theme.foreground.opacity(0.7))
+
             if store.sortedProducts.isEmpty {
                 Text("Loading subscription options…")
                     .font(.yoursMono(13))
@@ -41,8 +45,7 @@ struct SubscribeOptions: View {
             Button("Restore purchase") {
                 Task { await model.restorePurchases() }
             }
-            .font(.yoursMono(13))
-            .foregroundStyle(Theme.accent)
+            .buttonStyle(TextActionButtonStyle(color: Theme.accent))
             .disabled(store.purchasing)
 
             if let error = store.purchaseError {


### PR DESCRIPTION
## Summary
- tighten native sign-in state so repeated Google taps cannot start overlapping auth sessions
- improve chat/settings/paywall tap targets, header truncation, scrollability, and legal links without changing legal page copy
- recover failed sends by restoring the draft and offering retry, including server-sent SSE error events
- align sleep polling timeout with the web flow and avoid returning to stale pre-sleep chat state
- improve App Store restore/purchase error messages so real verification failures are not reported as no subscription