### PR TITLE
Name the Stripe custom checkout domain in CSP form-action

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -35,13 +35,17 @@ Rails.application.configure do
     policy.frame_ancestors :none
     policy.base_uri :self
     # forms post to self and the canonical host; Chrome enforces form-action
-    # through redirect chains, so the two off-site handoffs are named. HOST is
+    # through redirect chains, so every off-site handoff is named: Google for
+    # sign-in, and Stripe Checkout for subscriptions. Checkout runs on our
+    # custom domain (stripe.lightward.com); checkout.stripe.com stays named as
+    # the fallback Stripe uses when the custom domain isn't in play. HOST is
     # absent during boot-only contexts (asset precompilation, db tasks), so the
     # canonical host is included only when it's set — at request time it always is.
     canonical_host = ENV["HOST"]
     policy.form_action :self,
       *(canonical_host ? [ "https://#{canonical_host}" ] : []),
       "https://accounts.google.com",
+      "https://stripe.lightward.com",
       "https://checkout.stripe.com"
   end
 end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe "Content Security Policy", type: :request do
     expect(csp).to include("form-action 'self'")
     expect(csp).to include("https://#{ENV.fetch("HOST")}")
     expect(csp).to include("https://accounts.google.com")
+    # Stripe Checkout hands off on our custom domain; the default host stays named as fallback
+    expect(csp).to include("https://stripe.lightward.com")
     expect(csp).to include("https://checkout.stripe.com")
   end
 


### PR DESCRIPTION
## What

Subscription checkout was still blocked by CSP after #185, with a misleading console error:

> Sending form data to 'https://yours.fyi/subscription' violates the following Content Security Policy directive: "form-action 'self' https://yours.fyi https://accounts.google.com https://checkout.stripe.com". The request has been blocked.

## Why

A HAR of the live flow showed `POST /subscription` returns `303 → https://stripe.lightward.com/c/pay/cs_live_...`. Stripe Checkout for this account runs on a **custom domain** (`stripe.lightward.com`), not `checkout.stripe.com`.

Chrome enforces `form-action` across the redirect chain, so it blocks that unlisted hop — and reports the violation against the *original* `/subscription` URL, which made it look like `'self'` was being rejected even though it was allowed.

## Fix

Name `https://stripe.lightward.com` in `form-action`. `checkout.stripe.com` stays named as the fallback Stripe uses when the custom domain isn't in play. The CSP spec asserts both hosts as the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)