### PR TITLE
Sign in with Apple (backend + iOS) + repricing to $10/20/30/50/100

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,15 @@ GOOGLE_SIGN_IN_CLIENT_ID=
 GOOGLE_SIGN_IN_CLIENT_SECRET=
 
 STRIPE_SECRET_KEY=
-STRIPE_PRICE_ID_1=
+# Offered monthly tiers: $10 / $20 / $30 / $50 / $100
 STRIPE_PRICE_ID_10=
+STRIPE_PRICE_ID_20=
+STRIPE_PRICE_ID_30=
+STRIPE_PRICE_ID_50=
 STRIPE_PRICE_ID_100=
+# Retired tiers — set only if you have existing $1/$1000 subscribers to keep
+# recognized as active (grandfathering). Leave blank otherwise.
+STRIPE_PRICE_ID_1=
 STRIPE_PRICE_ID_1000=
 
 LIGHTWARD_AI_API_URL=https://lightward.com/api/stream
@@ -23,6 +29,15 @@ APPLE_IAP_ENVIRONMENT=Production
 # Google Play Developer API (service-account JSON for the androidpublisher scope):
 GOOGLE_PLAY_PACKAGE_NAME=fyi.yours.app
 GOOGLE_PLAY_SERVICE_ACCOUNT_JSON=
+
+# Sign in with Apple — verifying the identity token needs NO secret (Apple's
+# keys are public). aud defaults to APPLE_IAP_BUNDLE_ID; only set this if you
+# add extra client ids (e.g. a Services ID), comma-separated.
+APPLE_SIGN_IN_CLIENT_IDS=
+# Native subscription product ids default to fyi.yours.subscription.tier_10/20/
+# 30/50/100; override the offered/legacy sets here if your ids differ.
+APPLE_PRODUCT_IDS=
+APPLE_LEGACY_PRODUCT_IDS=
 
 FATHOM_SITE=
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -13,16 +13,29 @@ contract.
 ## Identity model (read this first)
 
 All data lives server-side, encrypted with a key derived from the person's
-Google ID (see `app/models/resonance.rb`). The server never stores that ID —
-it arrives with each request and is forgotten after:
+**identity_key** (see `app/models/resonance.rb`). The server never stores that
+key — it arrives with each request and is forgotten after:
 
 - **Web**: inside the encrypted Rails session cookie
 - **Native**: inside an encrypted bearer token (`Authorization: Bearer ...`),
   minted at sign-in, held in the device keychain
 
+The identity_key is the raw provider subject:
+
+- **Google sign-in** (web + native): the Google `sub`. (For historical
+  reasons the stored primary-key column is `encrypted_google_id_hash`; it now
+  holds `SHA256(identity_key)`, byte-identical to before for Google users.)
+- **Sign in with Apple** (native, iOS): `apple:<sub>`.
+
+The two providers are **parallel, never linked**: each derives its own
+encryption key from its own identity_key, so they're independent key spaces.
+A person who signs in with Google and (separately) with Apple has two distinct
+universes — there is no email-based or any other bridge between them. Bearer
+tokens minted before this change carried the key under `google_id`; the server
+still reads those, normalizing to `identity_key`.
+
 Both envelopes are sealed with server-side keys derived from
-`secret_key_base`. Neither is stored server-side. Two doors, one universe:
-the same Google account sees the same narrative everywhere.
+`secret_key_base`. Neither is stored server-side.
 
 ## Native sign-in handshake
 
@@ -47,11 +60,32 @@ browser sheet (PKCE-style):
 Tokens expire after a year; any 401 means sign in again. Bearer requests are
 exempt from CSRF (no cookies involved); cookie requests remain protected.
 
+## Sign in with Apple (native, iOS)
+
+A second, independent provider — offered alongside Google on the iOS landing
+screen (App Store guideline 4.8). It does **not** ride the web flow; it's a
+native credential exchange, and needs no consent gate because the token is
+already cryptographically bound to the app.
+
+1. The app runs `ASAuthorizationController`, generating a random `nonce` and
+   setting `request.nonce = sha256(nonce)`. Apple returns an `identityToken`
+   (a JWS).
+2. App `POST`s to `/native/apple_auth`: `{ identity_token, nonce }` (the raw
+   nonce).
+3. The server verifies the token against **Apple's public keys** (signature,
+   `iss = https://appleid.apple.com`, `aud =` our bundle id, not expired,
+   `nonce` claim `= sha256(nonce)`), extracts `sub`, and mints a bearer token
+   for `identity_key = "apple:<sub>"`. Returns `{ token, obfuscated_email }`
+   (email present only on the first sign-in). Verification failure → **401**
+   `apple_verification_failed`.
+
 ## Endpoints clients use
 
 | Endpoint | Auth | Returns |
 |---|---|---|
-| `GET /native/state` | bearer | `{ universe_day, universe_time, narrative, textarea, obfuscated_email, subscription_active }`; add `?include=subscription` for `subscription` details |
+| `POST /native/token` | PKCE code | Google sign-in: exchange code + verifier → `{ token, obfuscated_email }` |
+| `POST /native/apple_auth` | Apple JWT | Sign in with Apple: `{ identity_token, nonce }` → `{ token, obfuscated_email }` |
+| `GET /native/state` | bearer | `{ universe_day, universe_time, narrative, textarea, obfuscated_email, subscription_active, iap_account_token }`; add `?include=subscription` for `subscription` details |
 | `POST /stream` | either | SSE stream (below). Body: `{ message: { role, content: [{ type: "text", text }] } }` |
 | `PUT /textarea` | either | `{ status: "saved", universe_time }`. Body: `{ textarea }` |
 | `POST /sleep` | either | web: redirect; bearer: `{ status: "integrating", starting_universe_time }` — then poll `/native/state` until `universe_time` moves |
@@ -70,6 +104,15 @@ starting another subscription while any storefront is active. Each storefront
 still manages its own billing and cancellation; we record the identities
 needed to ask each storefront for current entitlement, but we don't reconcile
 or cancel across storefronts.
+
+**Pricing tiers.** The offered tiers are $10 / $20 / $30 / $50 / $100 per
+month, on both web and iOS. There are two lists per storefront: what we
+**offer** (`STRIPE_PRICE_IDS` / `APPLE_PRODUCT_IDS`) and what we **recognize
+as active** (`STRIPE_RECOGNIZED_PRICE_IDS` / `APPLE_RECOGNIZED_PRODUCT_IDS` =
+offered + grandfathered legacy `$1`/`$1000`). New checkouts only use the
+offered list; entitlement checks use the recognized list, so anyone still on a
+retired tier keeps access (their subscription lives at the storefront, which
+keeps billing regardless of what we offer).
 
 > **Google Play (Android) is implemented server-side but gated off** until
 > the Android client has a billing flow. `POST /native/subscription` with

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern, except: [
     :index, :terms, :privacy, :llms_txt,
     :native_auth_start, :native_auth_confirm_start, :native_auth_confirm, :native_auth_return,
-    :native_token, :native_state, :native_subscription,
+    :native_token, :native_apple_auth, :native_state, :native_subscription,
     :apple_notifications, :google_notifications
   ]
 
@@ -139,9 +139,33 @@ class ApplicationController < ActionController::Base
     return render json: { error: "invalid_code" }, status: :unauthorized unless payload
 
     render json: {
-      token: NativeToken.issue(google_id: payload["google_id"], obfuscated_email: payload["obfuscated_email"]),
+      token: NativeToken.issue(identity_key: payload["identity_key"], obfuscated_email: payload["obfuscated_email"]),
       obfuscated_email: payload["obfuscated_email"]
     }
+  end
+
+  # POST /native/apple_auth
+  # Sign in with Apple. The app runs the native flow and posts Apple's identity
+  # token plus the raw nonce it used. We verify the token with Apple's own keys
+  # (bound to our bundle id + the nonce) and mint a bearer token for the
+  # identity "apple:<sub>" — its own encryption key space, never linked to any
+  # Google resonance. No consent gate: the token is app-bound, so there's no
+  # confused-deputy risk the Google web flow has. See PROTOCOL.md.
+  def native_apple_auth
+    result = AppleIdentity.new.verify(
+      params[:identity_token].to_s,
+      raw_nonce: params[:nonce].to_s
+    )
+
+    resonance = Resonance.find_or_create_by_identity(result.identity_key)
+    obfuscated = obfuscate_email(result.email) # nil after first sign-in; that's fine
+
+    render json: {
+      token: NativeToken.issue(identity_key: resonance.identity_key, obfuscated_email: obfuscated),
+      obfuscated_email: obfuscated
+    }
+  rescue AppleIdentity::VerificationError => e
+    render json: { error: "apple_verification_failed", message: e.message }, status: :unauthorized
   end
 
   # GET /native/state
@@ -706,21 +730,18 @@ class ApplicationController < ActionController::Base
     # When a bearer token is present, it wins — a request carrying an
     # Authorization header is a device API call, and an ambient browser cookie
     # must not override (or stand in for) its identity. Otherwise fall back to
-    # the session cookie (the web path).
-    google_id =
+    # the session cookie (the web path). The identity_key is the Google sub for
+    # Google users, "apple:<sub>" for Apple; native_token_payload normalizes
+    # legacy tokens so ["identity_key"] is populated either way.
+    identity_key =
       if bearer_token_present?
-        native_token_payload&.[]("google_id")
+        native_token_payload&.[]("identity_key")
       else
         session[:google_id]
       end
-    return nil unless google_id
+    return nil unless identity_key
 
-    @current_resonance ||= begin
-      google_id_hash = Digest::SHA256.hexdigest(google_id)
-      resonance = Resonance.find_by(encrypted_google_id_hash: google_id_hash)
-      resonance.google_id = google_id if resonance
-      resonance
-    end
+    @current_resonance ||= Resonance.find_by_identity(identity_key)
   end
   helper_method :current_resonance
 
@@ -787,7 +808,7 @@ class ApplicationController < ActionController::Base
     return nil if session[:native_code_challenge].blank?
 
     code = NativeToken.issue_code(
-      google_id: session[:google_id],
+      identity_key: session[:google_id],
       obfuscated_email: session[:obfuscated_user_email],
       code_challenge: session.delete(:native_code_challenge)
     )

--- a/app/models/concerns/stripe_subscription.rb
+++ b/app/models/concerns/stripe_subscription.rb
@@ -13,9 +13,10 @@ module StripeSubscription
 
     return false unless subscriptions&.data
 
-    # Look for active subscriptions to any of our Yours price IDs
+    # Look for active subscriptions to any recognized Yours price ID (offered
+    # tiers + grandfathered legacy tiers).
     subscriptions.data.any? do |sub|
-      sub.items.data.any? { |item| STRIPE_PRICE_IDS.values.include?(item.price.id) }
+      sub.items.data.any? { |item| STRIPE_RECOGNIZED_PRICE_IDS.include?(item.price.id) }
     end
   rescue Stripe::StripeError => e
     Rails.logger.error "Stripe error checking subscription: #{e.message}"
@@ -63,9 +64,9 @@ module StripeSubscription
       limit: 10
     )
 
-    # Cancel all active Yours subscriptions
+    # Cancel all active Yours subscriptions (including grandfathered tiers).
     subscriptions.data.each do |sub|
-      if sub.items.data.any? { |item| STRIPE_PRICE_IDS.values.include?(item.price.id) }
+      if sub.items.data.any? { |item| STRIPE_RECOGNIZED_PRICE_IDS.include?(item.price.id) }
         if immediately
           # Cancel the subscription immediately
           Stripe::Subscription.cancel(sub.id)

--- a/app/models/native_token.rb
+++ b/app/models/native_token.rb
@@ -1,9 +1,14 @@
 # Mints and reads the encrypted credentials that let a native client (ios/,
-# android/) carry a resonance's google_id between requests, the same way the
+# android/) carry a resonance's identity_key between requests, the same way the
 # web session cookie does. Nothing minted here is stored server-side: the
 # token *is* the key envelope, and it lives only on the device. The
 # topological encryption story (see README) is unchanged — without a request
-# bearing the google_id, the data at rest remains structurally inaccessible.
+# bearing the identity_key, the data at rest remains structurally inaccessible.
+#
+# identity_key is the raw provider subject: the Google `sub` for Google
+# sign-in, "apple:<sub>" for Sign in with Apple. Tokens minted before this
+# change carried the key under "google_id"; read() still accepts those (they
+# live up to a year in keychains), normalizing them to identity_key.
 class NativeToken
   CODE_TTL = 1.minute   # one hop: web sign-in window -> app
   TOKEN_TTL = 1.year    # ordinary residence in the device keychain
@@ -12,11 +17,12 @@ class NativeToken
     # Short-lived exchange code, bound to a PKCE challenge so that only the
     # app instance that opened the sign-in window can redeem it — a code
     # intercepted in transit is useless without the verifier, which never
-    # leaves the device.
-    def issue_code(google_id:, obfuscated_email:, code_challenge:)
+    # leaves the device. (Used by the web Google flow; codes expire in a
+    # minute, so no legacy-key handling is needed here.)
+    def issue_code(identity_key:, obfuscated_email:, code_challenge:)
       encryptor.encrypt_and_sign(
         {
-          "google_id" => google_id,
+          "identity_key" => identity_key,
           "obfuscated_email" => obfuscated_email,
           "code_challenge" => code_challenge
         }.to_json,
@@ -25,8 +31,8 @@ class NativeToken
       )
     end
 
-    # Returns the code's payload if the verifier matches its challenge, nil
-    # otherwise (including expired or tampered codes).
+    # Returns the (normalized) code payload if the verifier matches its
+    # challenge, nil otherwise (including expired or tampered codes).
     def redeem_code(code, code_verifier:)
       payload = decode(code, purpose: :native_auth_code)
       return nil unless payload
@@ -34,13 +40,13 @@ class NativeToken
       challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier.to_s), padding: false)
       return nil unless ActiveSupport::SecurityUtils.secure_compare(challenge, payload["code_challenge"].to_s)
 
-      payload
+      normalize(payload)
     end
 
-    def issue(google_id:, obfuscated_email:)
+    def issue(identity_key:, obfuscated_email:)
       encryptor.encrypt_and_sign(
         {
-          "google_id" => google_id,
+          "identity_key" => identity_key,
           "obfuscated_email" => obfuscated_email
         }.to_json,
         purpose: :native_bearer,
@@ -48,12 +54,21 @@ class NativeToken
       )
     end
 
-    # Returns the token's payload, or nil for anything invalid or expired.
+    # Returns the (normalized) token payload, or nil for anything invalid or
+    # expired.
     def read(token)
-      decode(token, purpose: :native_bearer)
+      normalize(decode(token, purpose: :native_bearer))
     end
 
     private
+
+    # Bridge legacy tokens: a token minted before the identity_key rename
+    # carried the key under "google_id". Expose it as identity_key either way.
+    def normalize(payload)
+      return nil unless payload
+      payload["identity_key"] ||= payload["google_id"]
+      payload
+    end
 
     def decode(message, purpose:)
       payload = encryptor.decrypt_and_verify(message.to_s, purpose: purpose)

--- a/app/models/resonance.rb
+++ b/app/models/resonance.rb
@@ -18,30 +18,51 @@ class Resonance < ApplicationRecord
 
   validates :encrypted_google_id_hash, presence: true, uniqueness: true
 
-  # Encryption keyed to Google ID - without the Google ID, data is structurally inaccessible
-  attr_accessor :google_id
+  # Encryption is keyed to the identity_key — without it, the data is
+  # structurally inaccessible. The identity_key is the raw provider subject:
+  # for Google sign-in it's the Google `sub`; for Sign in with Apple it's
+  # "apple:<sub>". Two providers, two independent key spaces, no linking.
+  #
+  # The primary-key column is still named `encrypted_google_id_hash` for
+  # historical reasons; it holds SHA256(identity_key), which for existing
+  # Google resonances is byte-for-byte what it always was, so no data migrates.
+  attr_accessor :identity_key
 
-  # Accessor for google_id_hash (read-only, computed from encrypted field)
-  def google_id_hash
+  # Backward-compatible alias: existing callers set/read `.google_id`. For a
+  # Google resonance the identity_key *is* the Google sub, so this is a no-op
+  # rename that keeps all the old plumbing (controllers, sleep thread) working.
+  alias_method :google_id, :identity_key
+  alias_method :google_id=, :identity_key=
+
+  # Read-only hash of the identity (the stored primary key).
+  def identity_hash
     encrypted_google_id_hash
   end
+  alias_method :google_id_hash, :identity_hash
 
-  # Find or create by Google ID, setting up encryption context
-  def self.find_or_create_by_google_id(google_id)
-    google_id_hash = Digest::SHA256.hexdigest(google_id)
+  # Find or create by identity_key, setting up the encryption context.
+  def self.find_or_create_by_identity(identity_key)
+    hash = Digest::SHA256.hexdigest(identity_key)
 
-    resonance = find_or_initialize_by(encrypted_google_id_hash: google_id_hash)
-    resonance.google_id = google_id
+    resonance = find_or_initialize_by(encrypted_google_id_hash: hash)
+    resonance.identity_key = identity_key
     resonance.save! if resonance.new_record?
     resonance
   end
 
-  # Find by Google ID and decrypt
-  def self.find_by_google_id(google_id)
-    google_id_hash = Digest::SHA256.hexdigest(google_id)
-    resonance = find_by(encrypted_google_id_hash: google_id_hash)
-    resonance.google_id = google_id if resonance
+  def self.find_by_identity(identity_key)
+    resonance = find_by(encrypted_google_id_hash: Digest::SHA256.hexdigest(identity_key))
+    resonance.identity_key = identity_key if resonance
     resonance
+  end
+
+  # Google-named wrappers, kept for existing callers and specs.
+  def self.find_or_create_by_google_id(google_id)
+    find_or_create_by_identity(google_id)
+  end
+
+  def self.find_by_google_id(google_id)
+    find_by_identity(google_id)
   end
 
   # Encrypt data using Google ID as key
@@ -66,9 +87,9 @@ class Resonance < ApplicationRecord
   def decrypt_field(encrypted_value)
     return nil if encrypted_value.nil? || encrypted_value.blank?
 
-    # A missing google_id is an auth-flow bug, not bad data — surface it loudly.
-    unless google_id
-      raise MissingEncryptionKeyError, "Cannot decrypt field: google_id not set. This indicates an authentication flow error."
+    # A missing identity_key is an auth-flow bug, not bad data — surface it loudly.
+    unless identity_key
+      raise MissingEncryptionKeyError, "Cannot decrypt field: identity_key not set. This indicates an authentication flow error."
     end
 
     raw = Base64.strict_decode64(encrypted_value.to_s)
@@ -169,9 +190,11 @@ class Resonance < ApplicationRecord
     end
   end
 
-  # Derive encryption key from Google ID
+  # Derive the encryption key from the identity_key. The salt is unchanged, so
+  # for Google resonances (identity_key == the Google sub) this yields exactly
+  # the same key as before — existing ciphertext decrypts identically.
   def encryption_key
-    raise "Cannot encrypt/decrypt without google_id" unless google_id
-    OpenSSL::PKCS5.pbkdf2_hmac(google_id, "yours-resonance-salt", 100_000, 32, "sha256")
+    raise "Cannot encrypt/decrypt without identity_key" unless identity_key
+    OpenSSL::PKCS5.pbkdf2_hmac(identity_key, "yours-resonance-salt", 100_000, 32, "sha256")
   end
 end

--- a/app/services/apple_app_store.rb
+++ b/app/services/apple_app_store.rb
@@ -29,7 +29,10 @@ class AppleAppStore
 
   class VerificationError < StandardError; end
 
-  def initialize(config: APPLE_IAP_CONFIG, product_ids: APPLE_PRODUCT_IDS)
+  # Verifies against the RECOGNIZED set (offered + grandfathered legacy), so a
+  # purchase made before the pricing change still validates. The client only
+  # *offers* the new tiers.
+  def initialize(config: APPLE_IAP_CONFIG, product_ids: APPLE_RECOGNIZED_PRODUCT_IDS)
     @config = config
     @product_ids = product_ids
   end

--- a/app/services/apple_identity.rb
+++ b/app/services/apple_identity.rb
@@ -1,0 +1,123 @@
+# Verifies a "Sign in with Apple" identity token (a JWS the app receives from
+# ASAuthorizationController) and returns the stable Apple subject.
+#
+# Unlike the Google web flow, this token comes straight from Apple through the
+# native SDK and is cryptographically bound to our app (its `aud` is our bundle
+# id) and to a per-attempt nonce — so there's no confused-deputy risk, and no
+# consent gate is needed. We verify:
+#   - signature (RS256) against Apple's published JWKS
+#   - iss == https://appleid.apple.com
+#   - aud == our app's client id (the bundle id, for native SiwA)
+#   - exp not passed
+#   - nonce matches sha256(raw nonce the app used)  [replay protection]
+# then read `sub`.
+#
+# The resulting identity_key is "apple:<sub>" — its own key space, never linked
+# to any Google resonance.
+class AppleIdentity
+  ISSUER = "https://appleid.apple.com".freeze
+  KEYS_URL = "https://appleid.apple.com/auth/keys".freeze
+  KEYS_CACHE_TTL = 1.hour
+
+  Result = Struct.new(:sub, :email, keyword_init: true) do
+    def identity_key
+      "apple:#{sub}"
+    end
+  end
+
+  class VerificationError < StandardError; end
+
+  def initialize(config: APPLE_SIGN_IN_CONFIG)
+    @config = config
+  end
+
+  # Given the identity token (and the raw nonce the app generated for this
+  # sign-in), return a Result, or raise VerificationError. `raw_nonce` may be
+  # nil only if the client didn't use one — but we require it, since it's the
+  # replay defense.
+  def verify(identity_token, raw_nonce:)
+    raise VerificationError, "Missing identity token" if identity_token.blank?
+    raise VerificationError, "Missing nonce" if raw_nonce.blank?
+
+    claims = decode(identity_token)
+
+    verify_claim!(claims["iss"] == ISSUER, "issuer")
+    verify_claim!(Array(@config[:client_ids]).include?(claims["aud"]), "audience")
+    verify_claim!(nonce_matches?(claims["nonce"], raw_nonce), "nonce")
+    verify_claim!(claims["sub"].present?, "subject")
+
+    Result.new(sub: claims["sub"], email: claims["email"])
+  end
+
+  private
+
+  def verify_claim!(condition, name)
+    raise VerificationError, "Apple identity token failed #{name} check" unless condition
+  end
+
+  # sha256(raw_nonce), hex — the value the app passes as request.nonce and that
+  # Apple echoes in the token's `nonce` claim. Constant-time compared.
+  def nonce_matches?(token_nonce, raw_nonce)
+    return false if token_nonce.blank?
+    expected = Digest::SHA256.hexdigest(raw_nonce)
+    ActiveSupport::SecurityUtils.secure_compare(token_nonce.to_s, expected)
+  end
+
+  # Decodes + verifies signature/exp against Apple's JWKS. Refetches the key
+  # set once on a `kid` miss (Apple rotates keys). ExpiredSignature is a
+  # subclass of DecodeError, so it must be rescued first.
+  def decode(token)
+    JWT.decode(token, nil, true, decode_options(jwks)).first
+  rescue JWT::ExpiredSignature
+    raise VerificationError, "Apple identity token expired"
+  rescue JWT::DecodeError => e
+    # A kid miss / signature mismatch surfaces as a DecodeError; retry once
+    # with a freshly-fetched key set before giving up.
+    raise VerificationError, "Apple identity token signature invalid: #{e.message}" if @retried
+    @retried = true
+    decode_with_fresh_keys(token)
+  end
+
+  def decode_with_fresh_keys(token)
+    JWT.decode(token, nil, true, decode_options(jwks(force: true))).first
+  rescue JWT::ExpiredSignature
+    raise VerificationError, "Apple identity token expired"
+  rescue JWT::DecodeError => e
+    raise VerificationError, "Apple identity token signature invalid: #{e.message}"
+  end
+
+  def decode_options(key_set)
+    {
+      algorithms: [ "RS256" ],
+      jwks: key_set,
+      verify_expiration: true
+    }
+  end
+
+  def jwks(force: false)
+    Rails.cache.delete(cache_key) if force
+    cached = Rails.cache.read(cache_key)
+    return cached if cached
+
+    body = fetch_keys
+    Rails.cache.write(cache_key, body, expires_in: KEYS_CACHE_TTL)
+    body
+  end
+
+  def cache_key
+    "apple_identity:jwks"
+  end
+
+  def fetch_keys
+    uri = URI(KEYS_URL)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.read_timeout = 10
+    response = http.request(Net::HTTP::Get.new(uri))
+    raise VerificationError, "Apple JWKS fetch failed: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError, SocketError, Timeout::Error => e
+    raise VerificationError, "Apple JWKS unavailable: #{e.message}"
+  end
+end

--- a/app/services/google_play_store.rb
+++ b/app/services/google_play_store.rb
@@ -24,7 +24,8 @@ class GooglePlayStore
 
   class VerificationError < StandardError; end
 
-  def initialize(config: GOOGLE_PLAY_CONFIG, product_ids: GOOGLE_PRODUCT_IDS)
+  # Recognized set (offered + grandfathered), same reasoning as Apple.
+  def initialize(config: GOOGLE_PLAY_CONFIG, product_ids: GOOGLE_RECOGNIZED_PRODUCT_IDS)
     @config = config
     @product_ids = product_ids
   end

--- a/app/views/application/settings.html.erb
+++ b/app/views/application/settings.html.erb
@@ -69,24 +69,14 @@
       <p>How much does "new" cost for you?</p>
 
       <div class="flex-row gap-md">
-        <%= form_with url: subscription_path, method: :post, data: { turbo: false } do |f| %>
-          <%= f.hidden_field :tier, value: "tier_1" %>
-          <%= f.submit "$1/month", name: nil %>
-        <% end %>
-
-        <%= form_with url: subscription_path, method: :post, data: { turbo: false } do |f| %>
-          <%= f.hidden_field :tier, value: "tier_10" %>
-          <%= f.submit "$10/month", name: nil %>
-        <% end %>
-
-        <%= form_with url: subscription_path, method: :post, data: { turbo: false } do |f| %>
-          <%= f.hidden_field :tier, value: "tier_100" %>
-          <%= f.submit "$100/month", name: nil %>
-        <% end %>
-
-        <%= form_with url: subscription_path, method: :post, data: { turbo: false } do |f| %>
-          <%= f.hidden_field :tier, value: "tier_1000" %>
-          <%= f.submit "$1000/month", name: nil %>
+        <%# Rendered from the offered tiers (config/initializers/stripe.rb); the %>
+        <%# dollar label is derived from the tier name, e.g. tier_10 -> $10. %>
+        <% STRIPE_PRICE_IDS.each_key do |tier| %>
+          <% dollars = tier.to_s.split("_").last %>
+          <%= form_with url: subscription_path, method: :post, data: { turbo: false } do |f| %>
+            <%= f.hidden_field :tier, value: tier %>
+            <%= f.submit "$#{dollars}/month", name: nil %>
+          <% end %>
         <% end %>
       </div>
 

--- a/config/initializers/native_iap.rb
+++ b/config/initializers/native_iap.rb
@@ -19,6 +19,15 @@ APPLE_IAP_CONFIG = {
   environment: ENV.fetch("APPLE_IAP_ENVIRONMENT", "Production")
 }.freeze
 
+# Sign in with Apple (native). The identity token the app sends is verified
+# against Apple's public keys; its `aud` claim is our app's bundle id (for
+# native SiwA). Allow extra client ids (e.g. a Services ID) via env if ever
+# needed. No secret is required to *verify* — Apple's keys are public.
+APPLE_SIGN_IN_CONFIG = {
+  client_ids: (ENV["APPLE_SIGN_IN_CLIENT_IDS"]&.split(",")&.map(&:strip).presence ||
+    [ ENV.fetch("APPLE_IAP_BUNDLE_ID", "fyi.yours.app") ])
+}.freeze
+
 # Google Play Developer API (https://developers.google.com/android-publisher)
 GOOGLE_PLAY_CONFIG = {
   package_name: ENV.fetch("GOOGLE_PLAY_PACKAGE_NAME", "fyi.yours.app"),
@@ -26,19 +35,37 @@ GOOGLE_PLAY_CONFIG = {
   service_account_json: ENV["GOOGLE_PLAY_SERVICE_ACCOUNT_JSON"]
 }.freeze
 
-# The native product IDs that count as a Yours subscription, mirroring
-# STRIPE_PRICE_IDS. Defaults match the tier naming so local/dev StoreKit
-# config files line up without extra ENV.
+# Native product IDs, mirroring the Stripe tiers. Two lists, same reason as
+# Stripe: what we OFFER (new $10/$20/$30/$50/$100) vs. what we RECOGNIZE as a
+# valid subscription (offered + grandfathered legacy $1/$1000), so a purchase
+# made before the pricing change keeps its access. Defaults match the tier
+# naming so local/dev StoreKit config lines up without extra ENV.
 APPLE_PRODUCT_IDS = (ENV["APPLE_PRODUCT_IDS"]&.split(",")&.map(&:strip).presence || %w[
-  fyi.yours.subscription.tier_1
   fyi.yours.subscription.tier_10
+  fyi.yours.subscription.tier_20
+  fyi.yours.subscription.tier_30
+  fyi.yours.subscription.tier_50
   fyi.yours.subscription.tier_100
-  fyi.yours.subscription.tier_1000
 ]).freeze
 
+APPLE_RECOGNIZED_PRODUCT_IDS = (APPLE_PRODUCT_IDS + (
+  ENV["APPLE_LEGACY_PRODUCT_IDS"]&.split(",")&.map(&:strip).presence || %w[
+    fyi.yours.subscription.tier_1
+    fyi.yours.subscription.tier_1000
+  ]
+)).uniq.freeze
+
 GOOGLE_PRODUCT_IDS = (ENV["GOOGLE_PRODUCT_IDS"]&.split(",")&.map(&:strip).presence || %w[
-  subscription_tier_1
   subscription_tier_10
+  subscription_tier_20
+  subscription_tier_30
+  subscription_tier_50
   subscription_tier_100
-  subscription_tier_1000
 ]).freeze
+
+GOOGLE_RECOGNIZED_PRODUCT_IDS = (GOOGLE_PRODUCT_IDS + (
+  ENV["GOOGLE_LEGACY_PRODUCT_IDS"]&.split(",")&.map(&:strip).presence || %w[
+    subscription_tier_1
+    subscription_tier_1000
+  ]
+)).uniq.freeze

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,8 +1,20 @@
 Stripe.api_key = ENV["STRIPE_SECRET_KEY"]
 
+# Tiers we OFFER for new checkouts: $10 / $20 / $30 / $50 / $100 per month.
+# tier_10 and tier_100 predate the pricing change; tier_20/30/50 are new.
 STRIPE_PRICE_IDS = {
-  tier_1: ENV["STRIPE_PRICE_ID_1"],       # $1/month
   tier_10: ENV["STRIPE_PRICE_ID_10"],     # $10/month
-  tier_100: ENV["STRIPE_PRICE_ID_100"],   # $100/month
-  tier_1000: ENV["STRIPE_PRICE_ID_1000"]  # $1000/month
-}.freeze
+  tier_20: ENV["STRIPE_PRICE_ID_20"],     # $20/month
+  tier_30: ENV["STRIPE_PRICE_ID_30"],     # $30/month
+  tier_50: ENV["STRIPE_PRICE_ID_50"],     # $50/month
+  tier_100: ENV["STRIPE_PRICE_ID_100"]    # $100/month
+}.compact.freeze
+
+# Tiers we RECOGNIZE as an active subscription: everything offered, PLUS the
+# retired $1 and $1000 tiers. A subscription's price lives in Stripe, not our
+# DB — so if we stopped recognizing the old price IDs, an existing $1 or $1000
+# subscriber would keep being billed by Stripe while losing access here. This
+# grandfathers them: we no longer *offer* those tiers, but we still honor them.
+STRIPE_RECOGNIZED_PRICE_IDS = (
+  STRIPE_PRICE_IDS.values + [ ENV["STRIPE_PRICE_ID_1"], ENV["STRIPE_PRICE_ID_1000"] ]
+).compact.uniq.freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   post "native/auth/confirm", to: "application#native_auth_confirm"
   get "native/auth/return", to: "application#native_auth_return", as: :native_auth_return
   post "native/token", to: "application#native_token"
+  post "native/apple_auth", to: "application#native_apple_auth"
   get "native/state", to: "application#native_state"
   post "native/subscription", to: "application#native_subscription"
   delete "native/account", to: "application#destroy_account"

--- a/ios/Yours.storekit
+++ b/ios/Yours.storekit
@@ -15,27 +15,6 @@
         {
           "adHocOffers" : [],
           "codeOffers" : [],
-          "displayPrice" : "1.00",
-          "familyShareable" : false,
-          "groupNumber" : 1,
-          "internalID" : "yours_tier_1",
-          "introductoryOffer" : null,
-          "localizations" : [
-            {
-              "description" : "Maintain the conditions for the space",
-              "displayName" : "Yours — $1/month",
-              "locale" : "en_US"
-            }
-          ],
-          "productID" : "fyi.yours.subscription.tier_1",
-          "recurringSubscriptionPeriod" : "P1M",
-          "referenceName" : "Yours tier_1",
-          "subscriptionGroupID" : "yours_subscription_group",
-          "type" : "RecurringSubscription"
-        },
-        {
-          "adHocOffers" : [],
-          "codeOffers" : [],
           "displayPrice" : "10.00",
           "familyShareable" : false,
           "groupNumber" : 1,
@@ -57,6 +36,69 @@
         {
           "adHocOffers" : [],
           "codeOffers" : [],
+          "displayPrice" : "20.00",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "yours_tier_20",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Maintain the conditions for the space",
+              "displayName" : "Yours — $20/month",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "fyi.yours.subscription.tier_20",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Yours tier_20",
+          "subscriptionGroupID" : "yours_subscription_group",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "30.00",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "yours_tier_30",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Maintain the conditions for the space",
+              "displayName" : "Yours — $30/month",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "fyi.yours.subscription.tier_30",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Yours tier_30",
+          "subscriptionGroupID" : "yours_subscription_group",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "50.00",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "yours_tier_50",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Maintain the conditions for the space",
+              "displayName" : "Yours — $50/month",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "fyi.yours.subscription.tier_50",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Yours tier_50",
+          "subscriptionGroupID" : "yours_subscription_group",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
           "displayPrice" : "100.00",
           "familyShareable" : false,
           "groupNumber" : 1,
@@ -72,27 +114,6 @@
           "productID" : "fyi.yours.subscription.tier_100",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Yours tier_100",
-          "subscriptionGroupID" : "yours_subscription_group",
-          "type" : "RecurringSubscription"
-        },
-        {
-          "adHocOffers" : [],
-          "codeOffers" : [],
-          "displayPrice" : "1000.00",
-          "familyShareable" : false,
-          "groupNumber" : 1,
-          "internalID" : "yours_tier_1000",
-          "introductoryOffer" : null,
-          "localizations" : [
-            {
-              "description" : "Maintain the conditions for the space",
-              "displayName" : "Yours — $1000/month",
-              "locale" : "en_US"
-            }
-          ],
-          "productID" : "fyi.yours.subscription.tier_1000",
-          "recurringSubscriptionPeriod" : "P1M",
-          "referenceName" : "Yours tier_1000",
           "subscriptionGroupID" : "yours_subscription_group",
           "type" : "RecurringSubscription"
         }

--- a/ios/Yours/AppModel.swift
+++ b/ios/Yours/AppModel.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import StoreKit
 import SwiftUI
 
@@ -214,6 +215,38 @@ final class AppModel: ObservableObject {
         } catch is AuthFlow.Cancelled {
             // The human closed the sheet; nothing to say
         } catch {
+            landingError = "Sign-in didn't complete. Try again?"
+        }
+    }
+
+    // Sign in with Apple — a separate identity provider from Google. Called
+    // from the SignInWithAppleButton completion; `rawNonce` is the un-hashed
+    // nonce the button's request used (its hash is what Apple signed). The
+    // resulting universe is keyed to the Apple account, independent of Google.
+    func completeAppleSignIn(_ result: Result<ASAuthorization, Error>, rawNonce: String) async {
+        guard !isSigningIn else { return }
+        isSigningIn = true
+        landingError = nil
+        defer { isSigningIn = false }
+
+        switch result {
+        case .success(let authorization):
+            guard let identityToken = AppleSignIn.identityToken(from: authorization) else {
+                landingError = "Sign-in didn't complete. Try again?"
+                return
+            }
+            do {
+                let auth = try await api.appleAuth(identityToken: identityToken, nonce: rawNonce)
+                Keychain.token = auth.token
+                api.token = auth.token
+                landingError = nil
+                await refreshState()
+            } catch {
+                landingError = "Sign-in didn't complete. Try again?"
+            }
+        case .failure(let error):
+            // Cancellation is silent; anything else is a gentle retry prompt.
+            if let authError = error as? ASAuthorizationError, authError.code == .canceled { return }
             landingError = "Sign-in didn't complete. Try again?"
         }
     }

--- a/ios/Yours/Networking/AppleSignIn.swift
+++ b/ios/Yours/Networking/AppleSignIn.swift
@@ -1,0 +1,33 @@
+import AuthenticationServices
+import CryptoKit
+import Foundation
+
+// Helpers for the native Sign in with Apple flow. We use SwiftUI's
+// SignInWithAppleButton (Apple's blessed control) and drive the nonce
+// ourselves: the button's request closure sets `request.nonce` to the *hashed*
+// nonce, Apple echoes that hash in the identity token's `nonce` claim, and the
+// server re-checks it against sha256(raw nonce) — replay protection. So the
+// raw nonce must be kept between the request and the server exchange, and sent
+// alongside the token. See PROTOCOL.md and AppModel.completeAppleSignIn.
+enum AppleSignIn {
+    // A fresh random nonce (URL-safe alphabet; only randomness matters).
+    static func randomNonce(length: Int = 32) -> String {
+        var bytes = [UInt8](repeating: 0, count: length)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let charset = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._")
+        return String(bytes.map { charset[Int($0) % charset.count] })
+    }
+
+    static func sha256(_ input: String) -> String {
+        SHA256.hash(data: Data(input.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    // Pulls the identity token (a JWS string) out of a completed authorization.
+    static func identityToken(from authorization: ASAuthorization) -> String? {
+        guard
+            let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let data = credential.identityToken
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/ios/Yours/Networking/YoursAPI.swift
+++ b/ios/Yours/Networking/YoursAPI.swift
@@ -84,6 +84,23 @@ final class YoursAPI: @unchecked Sendable {
         return (token, object["obfuscated_email"] as? String)
     }
 
+    // Sign in with Apple: hand the server Apple's identity token plus the raw
+    // nonce the app used. The server verifies it against Apple's keys and mints
+    // a bearer token for the "apple:<sub>" identity. See PROTOCOL.md.
+    func appleAuth(identityToken: String, nonce: String) async throws -> (token: String, obfuscatedEmail: String?) {
+        var request = makeRequest("native/apple_auth", method: "POST")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "identity_token": identityToken,
+            "nonce": nonce
+        ])
+        let (data, response) = try await session.data(for: request)
+        try Self.check(response, data: data)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let token = object["token"] as? String
+        else { throw APIError.badResponse }
+        return (token, object["obfuscated_email"] as? String)
+    }
+
     func state(includeSubscription: Bool = false) async throws -> UniverseState {
         // Query items must go through URLComponents — URL.appending(path:)
         // would percent-encode the "?" into the path and miss the route.

--- a/ios/Yours/Store.swift
+++ b/ios/Yours/Store.swift
@@ -12,11 +12,14 @@ final class Store: ObservableObject {
     // One store for the app; AppModel drives it, views observe it directly.
     static let shared = Store()
 
+    // Offered tiers: $10 / $20 / $30 / $50 / $100. Must match the App Store
+    // Connect product ids and config/initializers/native_iap.rb (offered set).
     static let productIDs = [
-        "fyi.yours.subscription.tier_1",
         "fyi.yours.subscription.tier_10",
-        "fyi.yours.subscription.tier_100",
-        "fyi.yours.subscription.tier_1000"
+        "fyi.yours.subscription.tier_20",
+        "fyi.yours.subscription.tier_30",
+        "fyi.yours.subscription.tier_50",
+        "fyi.yours.subscription.tier_100"
     ]
 
     @Published var products: [Product] = []
@@ -25,7 +28,7 @@ final class Store: ObservableObject {
 
     private var updatesTask: Task<Void, Never>?
 
-    // The price tiers, ordered low to high — mirrors the web's $1/$10/$100/$1000
+    // The price tiers, ordered low to high ($10 → $100).
     var sortedProducts: [Product] {
         products.sorted { $0.price < $1.price }
     }

--- a/ios/Yours/Views/LandingView.swift
+++ b/ios/Yours/Views/LandingView.swift
@@ -1,7 +1,12 @@
+import AuthenticationServices
 import SwiftUI
 
 struct LandingView: View {
     @EnvironmentObject private var model: AppModel
+    @Environment(\.colorScheme) private var colorScheme
+    // Held between the button's request (which sets the hashed nonce) and its
+    // completion (which sends the raw nonce to the server).
+    @State private var appleRawNonce = ""
 
     var body: some View {
         VStack(spacing: 0) {
@@ -34,6 +39,26 @@ struct LandingView: View {
             .buttonStyle(WebButtonStyle())
             .accessibilityIdentifier("landing-google-button")
             .disabled(model.isSigningIn)
+
+            // Sign in with Apple — a second, independent identity provider,
+            // offered because a social login (Google) is (App Store guideline
+            // 4.8). Apple's own button; we set the hashed nonce on the request
+            // and hand the completion to the model, which posts the token +
+            // raw nonce to /native/apple_auth.
+            SignInWithAppleButton(.signIn) { request in
+                appleRawNonce = AppleSignIn.randomNonce()
+                request.requestedScopes = [ .fullName, .email ]
+                request.nonce = AppleSignIn.sha256(appleRawNonce)
+            } onCompletion: { result in
+                Task { await model.completeAppleSignIn(result, rawNonce: appleRawNonce) }
+            }
+            .signInWithAppleButtonStyle(colorScheme == .dark ? .white : .black)
+            .frame(maxWidth: 280)
+            .frame(height: 48)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .accessibilityIdentifier("landing-apple-button")
+            .disabled(model.isSigningIn)
+            .padding(.top, 16)
 
             if let error = model.landingError {
                 Text(error)

--- a/ios/Yours/Yours.entitlements
+++ b/ios/Yours/Yours.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -25,6 +25,9 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: fyi.yours.app
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_KEY_UIUserInterfaceStyle: ""
+        # Sign in with Apple. The capability must also be enabled on the App ID
+        # in the Apple Developer portal for device/TestFlight signing.
+        CODE_SIGN_ENTITLEMENTS: Yours/Yours.entitlements
     info:
       path: Yours/Info.plist
       properties:

--- a/spec/models/concerns/stripe_subscription_spec.rb
+++ b/spec/models/concerns/stripe_subscription_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe StripeSubscription do
         resonance.stripe_customer_id = customer_id
         resonance.save!
 
-        # Stub Stripe constants
+        # Stub Stripe constants (offered + recognized)
         stub_const("STRIPE_PRICE_IDS", {
-          tier_1: price_id,
           tier_10: "price_test_tier_10",
-          tier_100: "price_test_tier_100",
-          tier_1000: "price_test_tier_1000"
+          tier_100: "price_test_tier_100"
         })
+        stub_const("STRIPE_RECOGNIZED_PRICE_IDS", [
+          price_id, "price_test_tier_10", "price_test_tier_100", "price_test_tier_1000"
+        ])
       end
 
       it "returns true when customer has active subscription to our price" do
@@ -77,22 +78,49 @@ RSpec.describe StripeSubscription do
         expect(resonance.active_subscription?).to be false
       end
     end
+
+    # Grandfathering regression: a subscriber on a RETIRED tier (recognized but
+    # no longer offered) must stay active — Stripe keeps billing them, so we
+    # must keep honoring it.
+    context "with a grandfathered legacy tier" do
+      let(:customer_id) { "cus_legacy" }
+      let(:legacy_price) { "price_test_tier_1" } # $1, retired from offers
+
+      before do
+        resonance.stripe_customer_id = customer_id
+        resonance.save!
+        # Offered set does NOT include the legacy price; recognized set does.
+        stub_const("STRIPE_PRICE_IDS", { tier_10: "price_test_tier_10" })
+        stub_const("STRIPE_RECOGNIZED_PRICE_IDS", [ "price_test_tier_10", legacy_price ])
+
+        subscriptions = double("Stripe::ListObject", data: [
+          double(items: double(data: [ double(price: double(id: legacy_price)) ]))
+        ])
+        allow(Stripe::Subscription).to receive(:list).and_return(subscriptions)
+      end
+
+      it "still counts as an active subscription" do
+        expect(resonance.active_subscription?).to be true
+      end
+    end
   end
 
   describe "#create_checkout_session" do
-    let(:tier) { "tier_1" }
+    let(:tier) { "tier_10" }
     let(:success_url) { "https://example.com/success" }
     let(:cancel_url) { "https://example.com/cancel" }
-    let(:price_id) { "price_test_tier_1" }
+    let(:price_id) { "price_test_tier_10" }
     let(:customer_id) { "cus_test123" }
 
     before do
       stub_const("STRIPE_PRICE_IDS", {
-        tier_1: price_id,
-        tier_10: "price_test_tier_10",
-        tier_100: "price_test_tier_100",
-        tier_1000: "price_test_tier_1000"
+        tier_10: price_id,
+        tier_20: "price_test_tier_20",
+        tier_100: "price_test_tier_100"
       })
+      stub_const("STRIPE_RECOGNIZED_PRICE_IDS", [
+        price_id, "price_test_tier_20", "price_test_tier_100"
+      ])
     end
 
     it "creates a checkout session with correct parameters" do
@@ -257,7 +285,7 @@ RSpec.describe StripeSubscription do
 
   describe "#cancel_subscription" do
     let(:customer_id) { "cus_test123" }
-    let(:price_id) { "price_test_tier_1" }
+    let(:price_id) { "price_test_tier_10" }
     let(:subscription_id) { "sub_test123" }
 
     before do
@@ -265,11 +293,10 @@ RSpec.describe StripeSubscription do
       resonance.save!
 
       stub_const("STRIPE_PRICE_IDS", {
-        tier_1: price_id,
-        tier_10: "price_test_tier_10",
-        tier_100: "price_test_tier_100",
-        tier_1000: "price_test_tier_1000"
+        tier_10: price_id,
+        tier_100: "price_test_tier_100"
       })
+      stub_const("STRIPE_RECOGNIZED_PRICE_IDS", [ price_id, "price_test_tier_100" ])
     end
 
     it "cancels active subscription at period end" do

--- a/spec/models/resonance_spec.rb
+++ b/spec/models/resonance_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Resonance, type: :model do
       reloaded = Resonance.find_by(encrypted_google_id_hash: resonance.encrypted_google_id_hash)
       expect {
         reloaded.stripe_customer_id
-      }.to raise_error(Resonance::MissingEncryptionKeyError, /google_id not set/)
+      }.to raise_error(Resonance::MissingEncryptionKeyError, /identity_key not set/)
     end
 
     it "can encrypt and decrypt empty strings" do
@@ -179,7 +179,7 @@ RSpec.describe Resonance, type: :model do
 
       expect {
         resonance_without_key.decrypt_field(encrypted)
-      }.to raise_error(Resonance::MissingEncryptionKeyError, /google_id not set/)
+      }.to raise_error(Resonance::MissingEncryptionKeyError, /identity_key not set/)
     end
   end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -275,13 +275,18 @@ RSpec.describe ApplicationController, type: :request do
         sign_in_as(google_id)
         resonance.universe_day = 1
         resonance.save!
+        # The view renders one button per offered tier; give it prices to show.
+        stub_const("STRIPE_PRICE_IDS", {
+          tier_10: "p10", tier_20: "p20", tier_30: "p30", tier_50: "p50", tier_100: "p100"
+        })
       end
 
       it "shows settings page with subscription options" do
         get settings_path
         expect(response).to have_http_status(:success)
         expect(response.body).to include('How much does "new" cost for you?')
-        expect(response.body).to include("$1/month")
+        expect(response.body).to include("$10/month")
+        expect(response.body).to include("$100/month")
       end
     end
 
@@ -394,6 +399,9 @@ RSpec.describe ApplicationController, type: :request do
       context "when authenticated but no active subscription" do
         before do
           allow_any_instance_of(Resonance).to receive(:active_subscription?).and_return(false)
+          stub_const("STRIPE_PRICE_IDS", {
+            tier_10: "p10", tier_20: "p20", tier_30: "p30", tier_50: "p50", tier_100: "p100"
+          })
         end
 
         it "shows settings page with subscription buttons" do
@@ -401,8 +409,13 @@ RSpec.describe ApplicationController, type: :request do
 
           expect(response).to have_http_status(:success)
           expect(response.body).to include('How much does "new" cost for you?')
-          expect(response.body).to include("$1/month")
           expect(response.body).to include("$10/month")
+          expect(response.body).to include("$20/month")
+          expect(response.body).to include("$50/month")
+          expect(response.body).to include("$100/month")
+          # Retired tiers are no longer offered
+          expect(response.body).not_to include("$1/month")
+          expect(response.body).not_to include("$1000/month")
         end
 
         it "shows disabled 'start over' button with explanatory text" do
@@ -800,16 +813,18 @@ RSpec.describe ApplicationController, type: :request do
   end
 
   describe "POST /subscription" do
-    let(:tier) { "tier_1" }
+    let(:tier) { "tier_20" }
     let(:checkout_session) { double("Stripe::Checkout::Session", url: "https://checkout.stripe.com/test") }
 
     before do
       stub_const("STRIPE_PRICE_IDS", {
-        tier_1: "price_test_tier_1",
         tier_10: "price_test_tier_10",
-        tier_100: "price_test_tier_100",
-        tier_1000: "price_test_tier_1000"
+        tier_20: "price_test_tier_20",
+        tier_100: "price_test_tier_100"
       })
+      stub_const("STRIPE_RECOGNIZED_PRICE_IDS", [
+        "price_test_tier_10", "price_test_tier_20", "price_test_tier_100"
+      ])
     end
 
     context "when not authenticated" do

--- a/spec/requests/native_client_spec.rb
+++ b/spec/requests/native_client_spec.rb
@@ -227,6 +227,49 @@ RSpec.describe "Native client protocol", type: :request do
     end
   end
 
+  describe "POST /native/apple_auth (Sign in with Apple)" do
+    let(:apple_result) { AppleIdentity::Result.new(sub: "000123.apple.sub", email: "u@privaterelay.appleid.com") }
+
+    it "mints a bearer token for a verified Apple identity, keyed to apple:<sub>" do
+      allow_any_instance_of(AppleIdentity).to receive(:verify).and_return(apple_result)
+
+      post "/native/apple_auth", params: { identity_token: "signed.apple.jwt", nonce: "raw-nonce" }
+
+      expect(response).to have_http_status(:success)
+      token = JSON.parse(response.body).fetch("token")
+
+      # The token authenticates as the Apple identity — its own key space.
+      get "/native/state", headers: { "Authorization" => "Bearer #{token}" }
+      expect(response).to have_http_status(:success)
+
+      # A resonance exists under apple:<sub>, and NOT under the bare sub.
+      expect(Resonance.find_by_identity("apple:000123.apple.sub")).to be_present
+      expect(Resonance.find_by_identity("000123.apple.sub")).to be_nil
+    end
+
+    it "does not collide with a Google resonance that shares the raw sub string" do
+      # A Google user whose google_id happens to equal the Apple sub string
+      Resonance.find_or_create_by_google_id("000123.apple.sub")
+      allow_any_instance_of(AppleIdentity).to receive(:verify).and_return(apple_result)
+
+      expect {
+        post "/native/apple_auth", params: { identity_token: "signed.apple.jwt", nonce: "raw-nonce" }
+      }.to change(Resonance, :count).by(1) # a distinct apple:<sub> resonance
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "rejects an unverifiable Apple token with 401" do
+      allow_any_instance_of(AppleIdentity).to receive(:verify)
+        .and_raise(AppleIdentity::VerificationError, "bad signature")
+
+      post "/native/apple_auth", params: { identity_token: "forged", nonce: "raw-nonce" }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(JSON.parse(response.body)["error"]).to eq("apple_verification_failed")
+    end
+  end
+
   describe "structural opacity of transit artifacts" do
     # The topological encryption invariant extends to the native protocol:
     # nothing that travels through the handshake may expose the google_id,

--- a/spec/services/apple_identity_spec.rb
+++ b/spec/services/apple_identity_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+# AppleIdentity verifies a Sign in with Apple identity token against Apple's
+# public keys. These specs sign real tokens with a throwaway RSA key and stub
+# the JWKS fetch to return that key's public half — so the full crypto path
+# (signature, claims, nonce) is exercised without hitting Apple.
+RSpec.describe AppleIdentity do
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:jwk) { JWT::JWK.new(rsa_key) }
+  let(:client_id) { "fyi.yours.app" }
+  let(:raw_nonce) { "device-generated-raw-nonce" }
+  subject(:verifier) { described_class.new(config: { client_ids: [ client_id ] }) }
+
+  before do
+    # Every instance returns our test key set instead of fetching Apple's.
+    allow_any_instance_of(described_class).to receive(:fetch_keys)
+      .and_return({ "keys" => [ jwk.export ] })
+  end
+
+  def token(claims = {})
+    payload = {
+      "iss" => "https://appleid.apple.com",
+      "aud" => client_id,
+      "sub" => "000123.abcdef.4567",
+      "exp" => Time.now.to_i + 600,
+      "iat" => Time.now.to_i,
+      "nonce" => Digest::SHA256.hexdigest(raw_nonce),
+      "email" => "someone@privaterelay.appleid.com"
+    }.merge(claims)
+    JWT.encode(payload, rsa_key, "RS256", { kid: jwk.kid })
+  end
+
+  describe "#verify" do
+    it "returns the subject and email for a valid token" do
+      result = verifier.verify(token, raw_nonce: raw_nonce)
+      expect(result.sub).to eq("000123.abcdef.4567")
+      expect(result.identity_key).to eq("apple:000123.abcdef.4567")
+      expect(result.email).to eq("someone@privaterelay.appleid.com")
+    end
+
+    it "rejects a token from the wrong issuer" do
+      expect { verifier.verify(token("iss" => "https://evil.example.com"), raw_nonce: raw_nonce) }
+        .to raise_error(described_class::VerificationError, /issuer/)
+    end
+
+    it "rejects a token for a different audience (not our app)" do
+      expect { verifier.verify(token("aud" => "com.someone.else"), raw_nonce: raw_nonce) }
+        .to raise_error(described_class::VerificationError, /audience/)
+    end
+
+    it "rejects a token whose nonce doesn't match the raw nonce (replay defense)" do
+      expect { verifier.verify(token, raw_nonce: "a-different-nonce") }
+        .to raise_error(described_class::VerificationError, /nonce/)
+    end
+
+    it "rejects an expired token" do
+      expect { verifier.verify(token("exp" => Time.now.to_i - 60), raw_nonce: raw_nonce) }
+        .to raise_error(described_class::VerificationError, /expired/)
+    end
+
+    it "rejects a token signed by a key Apple doesn't publish" do
+      other_key = OpenSSL::PKey::RSA.generate(2048)
+      forged = JWT.encode(
+        { "iss" => "https://appleid.apple.com", "aud" => client_id, "sub" => "x",
+          "exp" => Time.now.to_i + 600, "nonce" => Digest::SHA256.hexdigest(raw_nonce) },
+        other_key, "RS256", { kid: "unknown-kid" }
+      )
+      expect { verifier.verify(forged, raw_nonce: raw_nonce) }
+        .to raise_error(described_class::VerificationError)
+    end
+
+    it "requires an identity token" do
+      expect { verifier.verify("", raw_nonce: raw_nonce) }
+        .to raise_error(described_class::VerificationError, /token/)
+    end
+
+    it "requires a nonce" do
+      expect { verifier.verify(token, raw_nonce: "") }
+        .to raise_error(described_class::VerificationError, /nonce/i)
+    end
+  end
+end


### PR DESCRIPTION
> **Update — the iOS UI is now in this PR too.** It's no longer backend-only. The landing screen has the Sign in with Apple button (Apple's `SignInWithAppleButton`, nonce → `/native/apple_auth`), the entitlement is wired, and the StoreKit product list is the new 5 tiers. Builds clean; landing screen verified in the simulator (both buttons, correct size/style). The **on-device** Apple round-trip still needs a real device + the capability enabled (checklist item A).

Backend half of the App-Store launch push. Two changes, both server-side and fully tested; the iOS UI half (the Apple button + new StoreKit product list) is a **follow-on PR**. This is safe to review and merge on its own — it doesn't change any client behavior until the iOS PR ships.

**268 specs, 0 failures. Rubocop clean. Boots clean.**

---

## 1. Sign in with Apple — parallel identity provider

Guideline 4.8 needs a privacy-preserving login alongside Google. This adds Sign in with Apple **without touching the encryption model** — it's a second, independent provider, never linked to Google.

- **`identity_key` seam:** `google_id` generalizes to `identity_key` (the raw provider subject). Google → the Google `sub` (unchanged: same PBKDF2 key, same SHA256 primary key, **zero data migration**). Apple → `apple:<sub>`, its own key space. `google_id` stays as a backward-compatible alias, so all existing plumbing is untouched.
- **`AppleIdentity`** verifies Apple's identity-token JWS against Apple's public JWKS (signature, `iss`, `aud` = bundle id, `exp`, and `sha256(nonce)` replay defense). No secret needed — Apple's keys are public.
- **`POST /native/apple_auth`** mints a bearer token for the Apple identity. No consent gate (the token is app-bound, so the confused-deputy risk the Google web flow guards against doesn't exist).
- A regression proves an Apple identity never collides with a Google resonance that happens to share the raw `sub` string.

## 2. Repricing → $10 / $20 / $30 / $50 / $100 (web + iOS)

Keeps `tier_10`/`tier_100`, adds `tier_20/30/50`, retires `$1`/`$1000` from offers — **with grandfathering.** A subscription's price lives at the storefront, not our DB, so dropping the old price IDs from recognition would keep billing an existing `$1`/`$1000` subscriber while cutting their access. Fix: split **offered** (checkout) from **recognized-as-active** (offered + grandfathered legacy). Existing old-tier subscribers keep access; we just stop offering those tiers. Web buttons now render dynamically from the config so they can't drift.

---

## ✅ Your part (external setup — none of it blocks reviewing/merging this code)

None of these are done yet; the code reads them from env / talks to the storefronts once you've set them up. Do them before the iOS follow-on PR ships to TestFlight.

### A. Apple Developer / Xcode
- [ ] **Enable the "Sign in with Apple" capability** on the App ID `fyi.yours.app` (Apple Developer → Identifiers → your App ID → Capabilities). Also add it in Xcode's Signing & Capabilities when the iOS PR lands.
- [ ] No secret to add for verifying the token — Apple's keys are public. (Only set `APPLE_SIGN_IN_CLIENT_IDS` if you ever add a Services ID; `aud` defaults to the bundle id.)

### B. App Store Connect — subscription products
- [ ] Create three **new** auto-renewable subscription products, in the existing subscription group, priced monthly:
  - `fyi.yours.subscription.tier_20` — $20
  - `fyi.yours.subscription.tier_30` — $30
  - `fyi.yours.subscription.tier_50` — $50
- [ ] Leave `tier_10` and `tier_100` as-is. Leave `tier_1`/`tier_1000` alone too (don't delete — grandfathering; just no longer offered).
- [ ] Fill each product's localization/review info so they're **"Ready to Submit"** — the first IAP change must ship attached to the app version.

### C. Stripe (web) — prices + env
- [ ] Create three **new** recurring monthly prices: **$20, $30, $50**. ($10 and $100 already exist.)
- [ ] Set these env vars on Fly (production) — new: `STRIPE_PRICE_ID_20`, `STRIPE_PRICE_ID_30`, `STRIPE_PRICE_ID_50`. Keep `STRIPE_PRICE_ID_10` and `STRIPE_PRICE_ID_100`.
- [ ] **Grandfathering:** if you have existing $1/$1000 Stripe subscribers, keep `STRIPE_PRICE_ID_1` / `STRIPE_PRICE_ID_1000` set on Fly so they stay recognized. If you're certain there are none, you can leave them unset.

### D. After the iOS follow-on PR
- [ ] Point `APPLE_PRODUCT_IDS` (or rely on the defaults) at the 5 new product ids; update `Yours.storekit` for local testing.
- [ ] Build → TestFlight smoke (real Apple sign-in on device + a sandbox purchase of a new tier) → submit the app version with the new IAPs, manual release after approval.

---

## What I'll do next (the iOS follow-on PR)
- Add the Sign in with Apple button (`ASAuthorizationController`) to the landing screen, POST the token to `/native/apple_auth`.
- Swap the iOS product id list + `Yours.storekit` to the 5 new tiers.
- Wire, build to a device, and hand you a TestFlight/submission checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
